### PR TITLE
Add kibana-plugin-helpers to repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "name": "datagen",
   "license": "Apache-2.0",
   "description": "none",
+  "scripts": {
+    "start": "plugin-helpers start",
+    "build": "plugin-helpers build"
+  },
   "dependencies": {
     "angular": "1.4.7",
     "angular-sanitize": "1.4.9",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/BigFunger/datagen.git"
   },
   "devDependencies": {
+    "@elastic/plugin-helpers": "~6.0.2",
     "expect.js": "0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ui-select": "0.19.4"
   },
   "kibana": {
-    "version": "6.0.0"
+    "version": "kibana"
   },
   "version": "0.0.1",
   "repository": {


### PR DESCRIPTION
- add plugin-helpers dependency
- add start and build scripts
- change version back to `kibana`

Now you can simply do `npm start` and `npm run build` to start the dev server or create a build. Since the kibana version is set to `kibana`, it will ask you for your target version.

```
$ npm run build

> datagen@0.0.1 build /repos/datagen
> plugin-helpers build

? What version of Kibana are you building for? 
```

At the end of a build, you'll have a new `.zip` file in `/build` that's all ready to install:

```
$ unzip -l build/datagen-0.0.1.zip | head
Archive:  build/datagen-0.0.1.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
      530  03-22-17 15:37   kibana/datagen/index.js
        0  03-22-17 15:49   kibana/datagen/node_modules/
      766  03-22-17 15:44   kibana/datagen/package.json
        0  03-22-17 15:49   kibana/datagen/public/
        0  03-22-17 15:49   kibana/datagen/server/
        0  03-22-17 15:49   kibana/datagen/webpackShims/
        0  03-22-17 15:49   kibana/datagen/node_modules/angular/
...
```